### PR TITLE
Ensure compatability with all versions of Rails 4.0.x, not just Rails 4.0.0

### DIFF
--- a/emailvision.gemspec
+++ b/emailvision.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency("httparty", "~> 0.12.0")
   s.add_dependency("crack", "~> 0.4.0")
   s.add_dependency("builder", ">= 3.0")
-  s.add_dependency("activesupport", ">= 3.0", "<= 4.0")
+  s.add_dependency("activesupport", ">= 3.0", "<= 4.0.1")
 end

--- a/emailvision.gemspec
+++ b/emailvision.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency("httparty", "~> 0.12.0")
   s.add_dependency("crack", "~> 0.4.0")
   s.add_dependency("builder", ">= 3.0")
-  s.add_dependency("activesupport", ">= 3.0", "<= 4.0.1")
+  s.add_dependency("activesupport", ">= 3.0", "~> 4.0.0")
 end


### PR DESCRIPTION
This gem (which is fantastic, might I add!) throws up an error when using Rails 4.0.1 and this fixes it by modifying the gemspec slightly to be somewhat more flexible.
